### PR TITLE
At boot, put in udev device mapping to undo network reversal on WRT1900ac

### DIFF
--- a/rootfs/etc/systemd/reverse-wrt1900v1-network-interfaces
+++ b/rootfs/etc/systemd/reverse-wrt1900v1-network-interfaces
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+if strings /dev/mtd3 | grep -w 'modelNumber=WRT1900AC' >> /dev/null
+then
+  if strings /dev/mtd3 | grep 'hw_revision=1' >>  /dev/null
+  then
+    echo '# On a Linksys WRT1900ac version 1, network interfaces are reversed.' > /etc/udev/rules.d/70-persistent-net.rules
+    echo '# These rules undo the reversal' >> /etc/udev/rules.d/70-persistent-net.rules
+    echo '# More info: https://github.com/Chadster766/McDebian/wiki/Reversed-network-interfaces-on-WRT1900ac' >> /etc/udev/rules.d/70-persistent-net.rules
+    echo 'SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="eth1"' >> /etc/udev/rules.d/70-persistent-net.rules
+    echo 'SUBSYSTEM=="net", ATTR{ifindex}=="3", NAME="eth0"' >> /etc/udev/rules.d/70-persistent-net.rules
+    echo 'SUBSYSTEM=="net", ATTR{ifindex}=="4", NAME="wlan1"' >> /etc/udev/rules.d/70-persistent-net.rules
+    echo 'SUBSYSTEM=="net", ATTR{ifindex}=="5", NAME="wlan0"' >> /etc/udev/rules.d/70-persistent-net.rules
+  fi
+fi
+exit 0

--- a/rootfs/etc/systemd/system/reverse-wrt1900v1-network-interfaces.service
+++ b/rootfs/etc/systemd/system/reverse-wrt1900v1-network-interfaces.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Reverse network interfaces on a Linksys WRT1900ac v1
+Documentation=https://github.com/Chadster766/McDebian/wiki/Reversed-network-interfaces-on-WRT1900ac
+After=localfs.target
+Before=systemd-udevd.service
+DefaultDependencies=no
+ConditionPathExists=!/etc/udev/rules.d/70-persistent-net.rules
+
+[Service]
+ExecStart=/etc/systemd/reverse-wrt1900v1-network-interfaces
+Type=oneshot
+RemainAfterExit=true
+
+[Install]
+WantedBy=sysinit.target


### PR DESCRIPTION
On Linksys WRT1900ac hardware version 1, network interfaces are reversed. This fix remaps the interfaces.