### PR TITLE
Stability improvement for network reversal on a wrt1900ac

### DIFF
--- a/rootfs/etc/systemd/system/reverse-wrt1900v1-network-interfaces.service
+++ b/rootfs/etc/systemd/system/reverse-wrt1900v1-network-interfaces.service
@@ -4,7 +4,6 @@ Documentation=https://github.com/Chadster766/McDebian/wiki/Reversed-network-inte
 After=localfs.target
 Before=systemd-udevd.service
 DefaultDependencies=no
-ConditionPathExists=/etc/udev/rules.d/70-persistent-net.rules
 
 [Service]
 ExecStart=/etc/systemd/reverse-wrt1900v1-network-interfaces

--- a/rootfs/etc/udev/rules.d/75-persistent-net-generator.rules
+++ b/rootfs/etc/udev/rules.d/75-persistent-net-generator.rules
@@ -1,0 +1,1 @@
+/dev/null


### PR DESCRIPTION
Create /etc/udev/rules.d/70-persistent-net.rules on every boot. This ensures that any changes to the file (due to package upgrade or manual editing) are reverted. 

Linking /etc/udev/rules.d/75-persistent-net-generator.rules to /dev/null overwrites rules in /lib/udev/rules.d/75-persistent-net-generator.rules which sometimes generates rules that map wifi network interface wlan0 to wlan2 and wlan1 to wlan3. Remapping causes hostapd to fail