### PR TITLE
Put in udev rules for network interface mapping on all WRT devices.

### DIFF
--- a/rootfs/etc/systemd/reverse-wrt1900v1-network-interfaces
+++ b/rootfs/etc/systemd/reverse-wrt1900v1-network-interfaces
@@ -1,16 +1,7 @@
 #!/bin/bash
 
-if strings /dev/mtd3 | grep -w 'modelNumber=WRT1900AC' >> /dev/null
-then
-  if strings /dev/mtd3 | grep 'hw_revision=1' >>  /dev/null
-  then
-    echo '# On a Linksys WRT1900ac version 1, network interfaces are reversed.' > /etc/udev/rules.d/70-persistent-net.rules
-    echo '# These rules undo the reversal' >> /etc/udev/rules.d/70-persistent-net.rules
-    echo '# More info: https://github.com/Chadster766/McDebian/wiki/Reversed-network-interfaces-on-WRT1900ac' >> /etc/udev/rules.d/70-persistent-net.rules
-    echo 'SUBSYSTEM=="net", ATTR{ifindex}=="2", NAME="eth1"' >> /etc/udev/rules.d/70-persistent-net.rules
-    echo 'SUBSYSTEM=="net", ATTR{ifindex}=="3", NAME="eth0"' >> /etc/udev/rules.d/70-persistent-net.rules
-    echo 'SUBSYSTEM=="net", ATTR{ifindex}=="4", NAME="wlan1"' >> /etc/udev/rules.d/70-persistent-net.rules
-    echo 'SUBSYSTEM=="net", ATTR{ifindex}=="5", NAME="wlan0"' >> /etc/udev/rules.d/70-persistent-net.rules
-  fi
-fi
+# The use of this file and the corresponding service (reverse-wrt1900v1-network-interfaces.service)
+# has been deprecated in favor of service udev-network-interface-rules
+# It exist for backward compatibility to ensure a smooth upgrade.
+
 exit 0

--- a/rootfs/etc/systemd/system/reverse-wrt1900v1-network-interfaces.service
+++ b/rootfs/etc/systemd/system/reverse-wrt1900v1-network-interfaces.service
@@ -1,3 +1,6 @@
+# This service has been deprecated in favor of service udev-network-interface-rules
+# It exist for backward compatibility to ensure a smooth upgrade.
+
 [Unit]
 Description=Reverse network interfaces on a Linksys WRT1900ac v1
 Documentation=https://github.com/Chadster766/McDebian/wiki/Reversed-network-interfaces-on-WRT1900ac
@@ -6,7 +9,7 @@ Before=systemd-udevd.service
 DefaultDependencies=no
 
 [Service]
-ExecStart=/etc/systemd/reverse-wrt1900v1-network-interfaces
+ExecStart=/bin/true
 Type=oneshot
 RemainAfterExit=true
 

--- a/rootfs/etc/systemd/system/sysinit.target.wants/udev-network-interface-rules.service
+++ b/rootfs/etc/systemd/system/sysinit.target.wants/udev-network-interface-rules.service
@@ -1,0 +1,1 @@
+/etc/systemd/system/udev-network-interface-rules.service

--- a/rootfs/etc/systemd/system/udev-network-interface-rules.service
+++ b/rootfs/etc/systemd/system/udev-network-interface-rules.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=udev network interface rules
+Documentation=https://github.com/Chadster766/McDebian/wiki/Udev-network-interface-rules
+After=localfs.target
+Before=systemd-udevd.service
+DefaultDependencies=no
+
+[Service]
+ExecStart=/etc/systemd/udev-network-interface-rules
+Type=oneshot
+RemainAfterExit=true
+
+[Install]
+WantedBy=sysinit.target

--- a/rootfs/etc/systemd/udev-network-interface-rules
+++ b/rootfs/etc/systemd/udev-network-interface-rules
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+if  strings /dev/mtd3 | grep -w 'modelNumber=WRT1900AC' >> /dev/null  &&  strings /dev/mtd3 | grep 'hw_revision=1' >>  /dev/null
+then
+    # Interfaces are reversed on WRT1900ac v1
+    ifindex_eth0=3
+    ifindex_eth1=2
+    ifindex_wlan0=5
+    ifindex_wlan1=4
+  else
+    # Interface mapping on a WRT1200ac, WRT1900ac v2 and WRT1900acs
+    ifindex_eth0=2
+    ifindex_eth1=3
+    ifindex_wlan0=4
+    ifindex_wlan1=5
+fi
+
+    echo '# Udev appears to mix up network interface mapping at times.' > /etc/udev/rules.d/70-persistent-net.rules
+    echo '# These rules ensure that physical interfaces are mapped correctly to names' >> /etc/udev/rules.d/70-persistent-net.rules
+    echo '# More info: https://github.com/Chadster766/McDebian/wiki/Udev-network-interface-rules' >> /etc/udev/rules.d/70-persistent-net.rules
+    echo "SUBSYSTEM==\"net\", ATTR{ifindex}==\"${ifindex_eth0}\", NAME=\"eth0\"" >> /etc/udev/rules.d/70-persistent-net.rules
+    echo "SUBSYSTEM==\"net\", ATTR{ifindex}==\"${ifindex_eth1}\", NAME=\"eth1\"" >> /etc/udev/rules.d/70-persistent-net.rules
+    echo "SUBSYSTEM==\"net\", ATTR{ifindex}==\"${ifindex_wlan0}\", NAME=\"wlan0\"" >> /etc/udev/rules.d/70-persistent-net.rules
+    echo "SUBSYSTEM==\"net\", ATTR{ifindex}==\"${ifindex_wlan1}\", NAME=\"wlan1\"" >> /etc/udev/rules.d/70-persistent-net.rules
+
+exit 0


### PR DESCRIPTION
This ensures that interfaces are consistent mapped to corresponding physical interfaces.